### PR TITLE
Introduce pipeline as code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
 
   try {
     if (params.CLEAN_WORKSPACE == true) {
-      cleanWs()
+      deleteDir()
     }
 
     stage('Checkout from SCM') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,98 @@
+#!/usr/bin/env groovy
+
+/**
+* Right now this is a <b>very</b> simple implementation of handling rpms and a puppet only build in the very same Jenkinsfile.</br>
+* In order to have the stages displayed properly in the Jenkins UI you should have the same stages for either way. If stages differ between job-run n-1 and n
+* the main page of the job will only display the current job run rather than the cool history of the last runs in the pipeline execution table.</br>
+* it's not a dynamic table, what a shame.
+*/
+node {
+
+  VERBOSE_MODE = params.VERBOSE ? true : false
+  bashExec = VERBOSE_MODE ? '/bin/bash -x' : '/bin/bash'
+
+  try {
+    if (params.CLEAN_WORKSPACE == true) {
+      cleanWs()
+    }
+
+    stage('Checkout from SCM') {
+      dir('scripts') {
+        git credentialsId: "${params.CREDENTIALS_ID_SOE_CI_IN_JENKINS}", branch: "${params.SOE_CI_BRANCH}", poll: false, url: "${params.SOE_CI_REPO_URL}"
+      }
+      dir('soe') {
+        git credentialsId: "${params.CREDENTIALS_ID_ACME_SOE_IN_JENKINS}", branch:"${params.ACME_SOE_BRANCH}" ,poll: false, url: "${params.ACME_SOE_REPO_URL}"
+      }
+    }
+
+    loadEnvVars()
+
+    stage('build') {
+      executeScript("${WORKSPACE}/scripts/rpmbuild.sh ${WORKSPACE}/soe/rpms", true)
+      executeScript("${WORKSPACE}/scripts/kickstartbuild.sh ${WORKSPACE}/soe/kickstarts", true)
+      executeScript("${WORKSPACE}/scripts/puppetbuild.sh ${WORKSPACE}/soe/puppet", false)
+    }
+
+    stage('push to Satellite'){
+      executeScript("${WORKSPACE}/scripts/rpmpush.sh ${WORKSPACE}/artefacts", true)
+      executeScript("${WORKSPACE}/scripts/puppetpush.sh ${WORKSPACE}/artefacts", false)
+      executeScript("${WORKSPACE}/scripts/kickstartpush.sh ${WORKSPACE}/artefacts", true)
+    }
+    stage('publish and promote CV') {
+      executeScript("${WORKSPACE}/scripts/publishcv.sh", false)
+    }
+    stage('run tests on VMs') {
+      if (params.REBUILD_VMS == true) {
+        executeScript("${WORKSPACE}/scripts/buildtestvms.sh")
+      } else {
+        executeScript("${WORKSPACE}/scripts/starttestvms.sh")
+      }
+      executeScript("${WORKSPACE}/scripts/pushtests.sh")
+      step([$class: "TapPublisher", testResults: "test_results/*.tap", ])
+    }
+  } finally {
+      stage('poweroff VMs') {
+        if (params.POWER_OFF_VMS_AFTER_BUILD == true) {
+          executeScript("${WORKSPACE}/scripts/powerofftestvms.sh")
+        } else {
+          println "test VMs are not shut down as per passed configuration"
+        }
+      }
+      stage('cleanup') {
+        executeScript("${WORKSPACE}/scripts/cleanup.sh")
+      }
+  }
+}
+
+/**
+* @fileName - it is assumed the file is located in $WORKSPACE/scripts
+*/
+def loadEnvVarsFromFile(String fileName) {
+  try {
+    load "${WORKSPACE}/scripts/$fileName"
+  } catch (e) {
+    println "Well, this is embarassing, but we couldn't load the file $fileName"
+    throw e
+  }
+}
+
+def loadEnvVars() {
+  loadEnvVarsFromFile("script-env-vars.groovy")
+  if (params.PUPPET_ONLY == true) {
+    loadEnvVarsFromFile("script-env-vars-puppet-only.groovy")
+  } else {
+    loadEnvVarsFromFile("script-env-vars-rpm.groovy")
+  }
+}
+
+def executeScript(String bashArguments) {
+  executeScript("$bashArguments", false)
+}
+
+def executeScript(String bashArguments, boolean rpmRelevant) {
+  if (rpmRelevant && params.PUPPET_ONLY == true) {
+    println "Skipping, puppet-only build."
+  } else {
+    sh "${bashExec} $bashArguments"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 Continuous Integration Scripts for Satellite 6
 ==============================================
 
+- - -
+
+* Author: Janine Eichler
+* Email: <jaeichle@redhat.com>
+* Revision: 0.4
+* Introduce proper pipeline
+
+- - -
+
 * Domain Architect: Eric Lavarde
 * Email: <elavarde@redhat.com>
 * Consultant: Patrick C. F. Ernzer
@@ -16,6 +25,18 @@ Continuous Integration Scripts for Satellite 6
 * Date: 2014-11-20
 * Revision: 0.1
 
+## Table of Contents
+* [Introduction](#introduction)
+* [Setup](#setup)
+  * [Jenkins Server](#jenkins-server)
+    * [Installation](#installation)
+    * [Create a Job which runs the pipeline](#create-a-job-which-runs-the-pipeline)
+    * [Create a job which polls the SCMs and then triggers the previously created job](#create-a-job-which-polls-the-scms-and-then-triggers-the-previously-created-job)
+  * [Git Repository](#git-repository)
+  * [Satellite 6](#satellite-6)
+  * [Bootstrapping](#bootstrapping)
+* [Getting Started](#getting-started)
+* [COMING SOON](#coming-soon)
 
 ## Introduction
 Continuous Integration for Infrastructure (CII) is a process by which the Operating System build ("build") component of a Standard Operating Environment (SOE) can be rapidly developed, tested and deployed.
@@ -78,19 +99,34 @@ NB I have SELinux disabled on the Jenkins server as I ran into too many problems
 ```
 * Now that Jenkins is running, browse to it's console at http://jenkinsserver:8080/
 * Select the 'Manage Jenkins' link, followed by 'Manage Plugins'. You will need to add the following plugins:
-    * Git Plugin
-    * Multiple SCMs Plugin
-    * TAP Plugin
-    * Conditional BuildStep Plugin
+    * [Git Plugin](https://wiki.jenkins.io/display/JENKINS/Git+Plugin)
+    * [Multiple SCMs Plugin](https://wiki.jenkins.io/display/JENKINS/Multiple+SCMs+Plugin)
+    * [TAP Plugin](https://wiki.jenkins.io/display/JENKINS/TAP+Plugin)
+    * [Pipeline Plugin](https://wiki.jenkins.io/display/JENKINS/Pipeline+Plugin)
+    * [Parametrized Trigger Plugin](https://wiki.jenkins.io/display/JENKINS/Parameterized+Trigger+Plugin)
+
+
 * Select 'Configure System'
     * Enable 'Environment variables' in the Global properties section and click save (there is no need to Add any). Failing to enable this property leads to https://github.com/RedHatSatellite/soe-ci/issues/48
 * Restart Jenkins
 * Add the `jenkins` user to the `mock` group (`usermod -a -G mock jenkins`). This will allow Jenkins to build RPMs.
-* Create `/var/www/html/pub/soe-repo` and `/var/www/html/pub/soe-puppet` and assign their ownership to the `jenkins` user. These will be used as the upstream repositories to publish artefacts to the satellite.
+* Create `/var/www/html/pub/soe-repo`, `/var/www/html/pub/soe-puppet` and assign their ownership to the `jenkins` user. These will be used as the upstream repositories to publish artefacts to the satellite.
+    * Create `/var/www/html/pub/soe-puppet-only` for the puppet only workflow and assign its ownership to the `jenkins` user. It serves for the puppet only workflow.
+    * The pipeline handles both full builds and puppet-only via variables, so set them up both.
 * `su` to the `jenkins` user (`su jenkins -s /bin/bash`) and use `ssh-keygen` to create an ssh keypair. These will be used for authentication to both the git repository, and to the satellite server.
-* Create one build plan per release you want to build for in Jenkins by creating the directory `/var/lib/jenkins/jobs/SOE-<release> (e.g. SOE-el7)` and copying in the  [config.xml] file
+
+#### Create a Job which runs the pipeline
+* Create a directory /var/lib/jenkins/jobs/<job-name> (e.g. *soe-el7*) and copy in the [config-jenkinsfile.xml](config-jenkinsfile.xml) file.
+* Afterwards, rename the file to "config.xml". Make sure the jenkins user owns the directory and files.
+* Reload the configuration from disk using 'Manage Jenkins -> Reload Configuration from Disk'.
 * Check that the build plan is visible and correct via the Jenkins UI, you will surely need to adapt the parameter values to your environment.
-    * you might need to reload the configuration from disk using 'Manage Jenkins -> Reload Configuration from Disk'.
+  * Make sure that in the "Pipeline" section of the job configuration the "Lightweight checkout" is ticked and that the value for "Script Path" points to the "Jenkinsfile" in your repository.
+
+#### Create a job which polls the SCMs and then triggers the previously created job
+* Create the directory /var/lib/jenkins/jobs/<job-name> (e.g. *scm-poll-for-soe-el7*) and copy in the [config.xml](config.xml) file. Make sure the jenkins user is the owner of both.
+* Reload the configuration from disk using 'Manage Jenkins -> Reload Configuration from Disk'.
+* Check that the build plan is visible and correct via the Jenkins UI, you will surely need to adapt the parameter values to your environment.
+
 
 ### Git Repository
 * Clone the following two git repos:
@@ -98,6 +134,10 @@ NB I have SELinux disabled on the Jenkins server as I ran into too many problems
     * https://github.com/RedHatEMEA/acme-soe This is a demo CI environment
 * Push these to a private git remote (or branch/fork on github).
 * Edit the build plan on your Jenkins instance so that the two SCM checkouts point (one for acme-soe, the other for soe-ci) point to your private git remote - you will need to edit both of these.
+* Make sure to set up the files `script-env-vars.groovy  script-env-vars-puppet-only.groovy  script-env-vars-rpm.groovy`
+    * be sure to have different PUPPET_REPO_ID for full build and puppet-only build.
+* Maintain your pipeline scrip `Jenkinsfile` in soe-ci.git
+* Commit and push to git
 
 ### Satellite 6
 * Install and register a Red Hat Satellite 6 as per the [instructions](https://access.redhat.com/site/documentation/en-US/Red_Hat_Satellite/6.0/html/Installation_Guide/index.html).
@@ -105,7 +145,9 @@ NB I have SELinux disabled on the Jenkins server as I ran into too many problems
 * Create a sync plan that does a daily sync of the RHEL product
 * Do an initial sync
 * Create a product called 'ACME SOE'
-* Create a puppet repository called 'Puppet' with an upstream repo of http://jenkinsserver/pub/soe-puppet
+* Create two Puppet repos
+    * One called 'Puppet' with an upstream repo of http://jenkinsserver/pub/soe-puppet
+    * One called 'Puppet only' with an upstream repo of http://jenkinsserver/pub/soe-puppet-only
 * Create an RPM repository called 'RPMs' with an upstream repo of http://jenkinsserver/pub/soe-repo
 * Do NOT create a sync plan for the ACME SOE product. This will be synced by Jenkins when needed.
     * keep an eye on [RHBZ #1132980](https://bugzilla.redhat.com/show_bug.cgi?id=1132980) if you use a web proxy at your site to download packages to the Satellite.
@@ -119,7 +161,10 @@ NB I have SELinux disabled on the Jenkins server as I ran into too many problems
 ### Bootstrapping
 In order to create a Content View on the satellite, you need some initial content. That can be generated by Jenkins.
 
-Now manually trigger a build on Jenkins. This will fail, however it will create some content in the output directories by building the demo RPMs and Puppet modules. Check that these are available then do the following tasks:
+Now manually trigger both
+* a normal build
+* a puppet-only build
+This will fail, however it will create some content in the output directories by building the demo RPMs and Puppet modules. Check that these are available then do the following tasks:
 
 * On the satellite, do a manual sync of your ACME SOE product. Check that it syncs correctly and you have got the RPMs and puppet modules that Jenkins built for you.
 * Add the ACME SOE RPM and Puppet repos to the Content View, along with the RHEL 7 RPMs and RHEL 7 Common repos, and any third party puppet modules that are needed.
@@ -129,13 +174,14 @@ Now manually trigger a build on Jenkins. This will fail, however it will create 
 * Create a hostgroup (I called mine 'Test Servers') that deploys machines on to the Compute Resource that you configured earlier, and uses the activation key that you created. Create a default root password and make a note of it.
 * Create a couple of initial test servers and deploy them. Ensure that they can see your private RPM and puppet repositories as well as the Red Hat repositories.
     * If you plan to use the conditional VM build feature, edit the comment field of your test host(s) with the names of the Puppet modules, RPM packages and/or kickstart files surrounded by '#' if they are relevant to be tested on this specific host. E.g. if the 'ssh' module is modified, a host will only be re-built and tested if its comment field contains the string '#ssh#'.
+* CReate one or two Host Collections and configure TESTVM_HOSTCOLLECTION in `script-env-vars-puppet-only.groovy` and `script-env-vars-rpm.groovy`
 
-### Getting Started
+FIXME: add instructions on HC
+
+## Getting Started
 At this point, you should be good to go. In fact Jenkins may have already kicked off a build for you when you pushed to github.
 
 Develop your build in your checkout of acme-soe. Software that you want packaging goes in 'rpms', puppet modules in 'puppet' and BATS tests  in 'tests'. You MUST update versions (in specfiles and metadata.json files) whenever you make a change, otherwise satellite6 will not pick up that you have new versions, even though Jenkins will have repackaged them.
 
 ## COMING SOON
-* Kickstart files (currently doesn't do anything)
-* Hiera usage
-* Selective BATS tests - currently all tests run on all test servers, irrespective of whether the puppet module that they are testing is installed
+* Documentation update for pipelines

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ NB I have SELinux disabled on the Jenkins server as I ran into too many problems
     * please see [this post on the Satellite blog](https://access.redhat.com/blogs/1169563/posts/2191211) for a more detailled explanation on mock with Satellite 6.
     * make sure the baseurl points at your Satellite server. The easiest way to do this is to just copy the relevant repo blocks from the Jenkins server's `/etc/yum.repos.d/redhat.repo`
     * if your Jenkins server is able to access the Red Hat CDN, then you can leave the baseurls pointing at https://cdn.redhat.com
+    * if you are getting mock errors related to _systemd-nspawn_ then add `config_opts['use_nspawn'] = False` to your relevant mock config files.
 * Install `jenkins`, `tomcat` and Java. If you have setup the Jenkins repo correctly you should be able to simply use yum.
     * `[root@jenkins ~]# yum install jenkins tomcat java`
 * Ensure that `jenkins` is enabled, running and reachable.

--- a/config-jenkinsfile.xml
+++ b/config-jenkinsfile.xml
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.11.1">
+  <actions>
+    <org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction plugin="workflow-multibranch@2.16">
+      <jobPropertyDescriptors>
+        <string>org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty</string>
+        <string>hudson.model.ParametersDefinitionProperty</string>
+        <string>jenkins.model.BuildDiscarderProperty</string>
+      </jobPropertyDescriptors>
+    </org.jenkinsci.plugins.workflow.multibranch.JobPropertyTrackerAction>
+  </actions>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>30</daysToKeep>
+        <numToKeep>60</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty/>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>CREDENTIALS_ID_SOE_CI_IN_JENKINS</name>
+          <description>The credentials id of the user configured in Jenkins to checkout the soe-ci repo.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>SOE_CI_REPO_URL</name>
+          <description>The git repoistory url to checkout the &apos;soe-ci&apos; project.</description>
+          <defaultValue>git@localhost:repo/soe-ci.git</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>SOE_CI_BRANCH</name>
+          <description>The branch to checkout of the &apos;soe-ci&apos; repo.</description>
+          <defaultValue>master</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CREDENTIALS_ID_ACME_SOE_IN_JENKINS</name>
+          <description>The credentials id of the user configured in Jenkins to checkout the acme-soe repo.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ACME_SOE_REPO_URL</name>
+          <description>The git repoistory url to checkout the &apos;acme-soe&apos; project.</description>
+          <defaultValue>git@localhost:another-repo/acme-soe.git</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>ACME_SOE_BRANCH</name>
+          <description>The branch to checkout of the &apos;acme-soe&apos; repo.</description>
+          <defaultValue>master</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>REBUILD_VMS</name>
+          <description>Whether or not to rebuild the test VMs before running the tests</description>
+          <defaultValue>true</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>POWER_OFF_VMS_AFTER_BUILD</name>
+          <description>Whether or not to power off the VMs after the build. The build result (successful / failed) is not taken into consideration.</description>
+          <defaultValue>true</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>PUPPET_ONLY</name>
+          <description>Whether or not only puppet modules should be built and pushed.</description>
+          <defaultValue>false</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>CLEAN_WORKSPACE</name>
+          <description>Whether or not to clean the workspace before the job execution.</description>
+          <defaultValue>false</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>VERBOSE</name>
+          <description>Whether or not to run the executed scripts in a verbose mode.</description>
+          <defaultValue>false</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+    <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <triggers/>
+    </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.36">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@3.3.0">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>git@lcoalhost:repo/soe-ci.git</url>
+          <credentialsId></credentialsId>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>*/master</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions/>
+    </scm>
+    <scriptPath>Jenkinsfile</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>

--- a/config.xml
+++ b/config.xml
@@ -1,122 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description>Generic plan to create Red Hat Enterprise Linux builds</description>
+  <description>this polls both the soe-ci and the acme-soe repos so that we trigger a run of the pipeline job, no matter which of the two repos changed.&#xd;
+we also nail down REBUILD_VMS, PUPPET_ONLY and POWER_OFF_VMS_AFTER_BUILD</description>
   <keepDependencies>false</keepDependencies>
-  <properties>
-    <hudson.model.ParametersDefinitionProperty>
-      <parameterDefinitions>
-        <hudson.model.StringParameterDefinition>
-          <name>PUSH_USER</name>
-          <description>The username to use when pushing artefacts to the satellite. The build job will need to be able to ssh to the satellite as this user so you need to have keys set up.</description>
-          <defaultValue>jenkins</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>RSA_ID</name>
-          <description>RSA ID of the Jenkins user.</description>
-          <defaultValue>/var/lib/jenkins/.ssh/id_rsa</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>KNOWN_HOSTS</name>
-          <description>Known hosts file of the Jenkins user.</description>
-          <defaultValue>/var/lib/jenkins/.ssh/known_hosts</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>SATELLITE</name>
-          <description>The FQDN of the Red Hat Satellite.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>ORG</name>
-          <description>This is the name of the organisation you are using on the Red Hat Satellite.</description>
-          <defaultValue>Default_Organization</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>REPO_ID</name>
-          <description>The numeric ID of the RPM repository on the Red Hat Satellite that you want to use for your custom RPMs.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>PUPPET_REPO_ID</name>
-          <description>The numeric ID of the puppet module repository on the Red Hat Satellite that you want to use for your custom puppet modules.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>TESTVM_HOSTCOLLECTION</name>
-          <description>The name of the Satellite 6 host collection containing your test machines.</description>
-          <defaultValue>Test Servers</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>TESTVM_ENV</name>
-          <description>The numeric ID of the environment you want to promote CI builds to. This will typically be a &apos;Crash&apos; or &apos;EngTest&apos; environment.
-
-You can find the IDs of your environments using:
-hammer lifecycle-environment list --organization &quot;Default_Organization&quot;</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>TEST_ROOT</name>
-          <description>This is the root password of your test machines, as set in your hostgroup definition.</description>
-          <defaultValue>redhat</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>MODAUTHOR</name>
-          <description>This is the authorname for your puppet modules.</description>
-          <defaultValue>acme</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>YUM_REPO</name>
-          <description>This is the location of the Yum repository on the Jenkins server used to export RPMs to the satellite server.</description>
-          <defaultValue>/var/www/html/pub/soe-repo</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>PUPPET_REPO</name>
-          <description>This is the location of the puppet repository on the Jenkins server used to export puppet modules to the satellite server.</description>
-          <defaultValue>/var/www/html/pub/soe-puppet</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>CV</name>
-          <description>This is the name of the Content View on the satellite that you want to publish your build into.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>CV_PASSIVE_LIST</name>
-          <description>A comma separated list of content view names to publish and optionally promote as part of the build.
-Those CVs won&apos;t get new Puppet Modules assigned to them, meaning you must (and are free to) assign (and unassign) them yourself directly in Satellite.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>CCV_NAME_PATTERN</name>
-          <description>Enter here a name pattern if you want Composite Content Views using the given CV(s) to be updated with the latest version and as well published and promoted.
-CCVs respecting the pattern but not containing any CV will not be touched.
-Example of pattern: &quot;ccv-test-*&quot;</description>
-          <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.BooleanParameterDefinition>
-          <name>CONDITIONAL_VM_BUILD</name>
-          <description>If this parameter is true/set, only the hosts existing in Satellite with a comment matching
-the modified Puppet module, RPM package or kickstart file, each surrounded by hashes (#), will be built and tested.
-&lt;br/&gt;
-Examples: &lt;code&gt;#ssh#bats#kickstart.erb#&lt;/code&gt;
-&lt;br/&gt;
-&lt;b&gt;CAUTION:&lt;/b&gt; be aware that in this case, no host will be tested if only the scripts have been modified.
-&lt;br/&gt;
-If unset/false, all existing hosts, within the given Host Collection, will be rebuilt independent of changes done in Git.</description>
-          <defaultValue>false</defaultValue>
-        </hudson.model.BooleanParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>MOCK_CONFIG</name>
-          <description>This will be passed to mock --root
-e.g. mock --root rhel-6-x86_64
-needed to ensure we can build RPMs against more then just the default mock chroot.</description>
-          <defaultValue>rhel-6-x86_64</defaultValue>
-        </hudson.model.StringParameterDefinition>
-      </parameterDefinitions>
-    </hudson.model.ParametersDefinitionProperty>
-  </properties>
-  <scm class="org.jenkinsci.plugins.multiplescms.MultiSCM" plugin="multiple-scms@0.3">
+  <properties/>
+  <scm class="org.jenkinsci.plugins.multiplescms.MultiSCM" plugin="multiple-scms@0.6">
     <scms>
-      <hudson.plugins.git.GitSCM plugin="git@2.2.7">
+      <hudson.plugins.git.GitSCM plugin="git@3.3.1">
         <configVersion>2</configVersion>
         <userRemoteConfigs>
           <hudson.plugins.git.UserRemoteConfig>
@@ -130,13 +21,9 @@ needed to ensure we can build RPMs against more then just the default mock chroo
         </branches>
         <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
         <submoduleCfg class="list"/>
-        <extensions>
-          <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-            <relativeTargetDir>scripts</relativeTargetDir>
-          </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-        </extensions>
+        <extensions/>
       </hudson.plugins.git.GitSCM>
-      <hudson.plugins.git.GitSCM plugin="git@2.2.7">
+      <hudson.plugins.git.GitSCM plugin="git@3.3.1">
         <configVersion>2</configVersion>
         <userRemoteConfigs>
           <hudson.plugins.git.UserRemoteConfig>
@@ -150,11 +37,7 @@ needed to ensure we can build RPMs against more then just the default mock chroo
         </branches>
         <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
         <submoduleCfg class="list"/>
-        <extensions>
-          <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-            <relativeTargetDir>soe</relativeTargetDir>
-          </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-        </extensions>
+        <extensions/>
       </hudson.plugins.git.GitSCM>
     </scms>
   </scm>
@@ -162,102 +45,44 @@ needed to ensure we can build RPMs against more then just the default mock chroo
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers>
-    <hudson.triggers.SCMTrigger>
-      <spec>* * * * * </spec>
-      <ignorePostCommitHooks>false</ignorePostCommitHooks>
-    </hudson.triggers.SCMTrigger>
-  </triggers>
-  <concurrentBuild>false</concurrentBuild>
-  <builders>
-    <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
-echo &quot;#                BUILDING RPMS                      #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/rpmbuild.sh ${WORKSPACE}/soe/rpms
-
-echo &quot;#####################################################&quot;
-echo &quot;#                BUILDING PUPPET MODULES            #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/puppetbuild.sh ${WORKSPACE}/soe/puppet
-
-echo &quot;#####################################################&quot;
-echo &quot;#                BUILDING KICKSTARTS                #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/kickstartbuild.sh ${WORKSPACE}/soe/kickstarts
-</command>
-    </hudson.tasks.Shell>
-    <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
-echo &quot;#                PUSH RPMS TO SATELLITE             #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/rpmpush.sh ${WORKSPACE}/artefacts
-echo &quot;#####################################################&quot;
-echo &quot;#         PUSH PUPPET MODULES TO SATELLITE          #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/puppetpush.sh ${WORKSPACE}/artefacts
-echo &quot;#####################################################&quot;
-echo &quot;#           PUSH KICKSTARTS TO SATELLITE            #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/kickstartpush.sh ${WORKSPACE}/artefacts
-echo &quot;#####################################################&quot;
-echo &quot;#           REPUBLISH CONTENT VIEW                  #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/publishcv.sh</command>
-    </hudson.tasks.Shell>
-    <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
-echo &quot;#                REBUILDING TEST VMS                #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/buildtestvms.sh
-</command>
-    </hudson.tasks.Shell>
-    <hudson.tasks.Shell>
-      <command>echo &quot;#####################################################&quot;
-echo &quot;#            PUSHING TESTS to TEST VMS              #&quot;
-echo &quot;#####################################################&quot;
-/bin/bash -x ${WORKSPACE}/scripts/pushtests.sh
-</command>
-    </hudson.tasks.Shell>
-    <org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.3.6">
-      <condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.0">
-        <worstResult>
-          <name>SUCCESS</name>
-          <ordinal>0</ordinal>
-          <color>BLUE</color>
-          <completeBuild>true</completeBuild>
-        </worstResult>
-        <bestResult>
-          <name>SUCCESS</name>
-          <ordinal>0</ordinal>
-          <color>BLUE</color>
-          <completeBuild>true</completeBuild>
-        </bestResult>
-      </condition>
-      <buildStep class="hudson.tasks.Shell">
-        <command>echo &quot;#####################################################&quot;
-  echo &quot;#          CLEAN-UP AFTER SUCCESS BUILD             #&quot;
-  echo &quot;#####################################################&quot;
-  /bin/bash -x ${WORKSPACE}/scripts/cleanup.sh
-  </command>
-      </buildStep>
-      <runner class="org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail" plugin="run-condition@1.0"/>
-    </org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder>
-  </builders>
-  <publishers>
-    <org.tap4j.plugin.TapPublisher plugin="tap@1.20">
-      <testResults>test_results/*.tap</testResults>
-      <failIfNoResults>false</failIfNoResults>
-      <failedTestsMarkBuildAsFailure>false</failedTestsMarkBuildAsFailure>
-      <outputTapToConsole>false</outputTapToConsole>
-      <enableSubtests>false</enableSubtests>
-      <discardOldReports>true</discardOldReports>
-      <todoIsFailure>false</todoIsFailure>
-      <includeCommentDiagnostics>false</includeCommentDiagnostics>
-      <validateNumberOfTests>false</validateNumberOfTests>
-      <planRequired>true</planRequired>
-      <verbose>true</verbose>
-    </org.tap4j.plugin.TapPublisher>
-  </publishers>
-  <buildWrappers/>
+<triggers>
+  <hudson.triggers.SCMTrigger>
+    <spec>* * * * *</spec>
+    <ignorePostCommitHooks>false</ignorePostCommitHooks>
+  </hudson.triggers.SCMTrigger>
+</triggers>
+<concurrentBuild>false</concurrentBuild>
+<builders>
+  <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.34">
+    <configs>
+      <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <configs>
+          <hudson.plugins.parameterizedtrigger.BooleanParameters>
+            <configs>
+              <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                <name>REBUILD_VMS</name>
+                <value>false</value>
+              </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+              <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                <name>PUPPET_ONLY</name>
+                <value>false</value>
+              </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+              <hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+                <name>POWER_OFF_VMS_AFTER_BUILD</name>
+                <value>true</value>
+              </hudson.plugins.parameterizedtrigger.BooleanParameterConfig>
+            </configs>
+          </hudson.plugins.parameterizedtrigger.BooleanParameters>
+        </configs>
+        <projects>soe-el7</projects>
+        <condition>UNSTABLE_OR_BETTER</condition>
+        <triggerWithNoParameters>false</triggerWithNoParameters>
+        <triggerFromChildProjects>false</triggerFromChildProjects>
+        <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+      </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+    </configs>
+  </hudson.plugins.parameterizedtrigger.TriggerBuilder>
+</builders>
+<publishers/>
+<buildWrappers/>
 </project>

--- a/puppet-done-test.sh
+++ b/puppet-done-test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+NO_ARGS=0
+OPTERROR=65
+
+usage()
+{
+  echo "Usage: $0 -s <seconds>"
+  echo "       s = number of seconds to sleep"
+  exit 1
+}
+if [ $# -eq "$NO_ARGS" ]
+then
+  usage
+fi
+
 look_for_state()
 {
   while [[ ! -d /var/lib/puppet/state ]]
@@ -43,10 +57,23 @@ look_for_finished()
 
 date
 
-# waiting just over one minute for puppet to start
-# this script gets run on first boot after a system was installed
-echo "waiting 75 seconds (one minute and a bit) before checking on puppet"
-sleep 75
+while getopts "c:n:s:h" Option
+do
+  case $Option in
+    s) SLEEP=${OPTARG}
+    ;;
+    h)
+      usage
+    ;;
+    *) echo "Non valid switch"
+    ;;
+  esac
+done
+
+# if you run puppet on boot, sleep 75 seconds (just over a minute)
+# if this is a run in the puppet only workflow, no real need to sleep
+echo "waiting ${SLEEP} seconds before checking on puppet"
+sleep ${SLEEP}
 
 # /var/lib/puppet/state gets created on first run?
 look_for_state

--- a/pushtests.sh
+++ b/pushtests.sh
@@ -80,6 +80,10 @@ do
     scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${RSA_ID} \
         ${WORKSPACE}/scripts/puppet-done-test.sh root@$I:
 
+    # run puppet once, this will skip if puppet already running, so no need for if clause
+    ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${RSA_ID} root@$I \
+        "puppet agent -t"
+
     # wait for puppet to finish
     ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${RSA_ID} root@$I \
         "/root/puppet-done-test.sh -s ${PUPPET_DONE_SLEEP}"

--- a/pushtests.sh
+++ b/pushtests.sh
@@ -82,7 +82,7 @@ do
 
     # wait for puppet to finish
     ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${RSA_ID} root@$I \
-        "/root/puppet-done-test.sh"
+        "/root/puppet-done-test.sh -s ${PUPPET_DONE_SLEEP}"
 
     info "Installing bats and rsync on test server $I"
     if ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${RSA_ID} root@$I \

--- a/rhel-6-x86_64.cfg
+++ b/rhel-6-x86_64.cfg
@@ -6,6 +6,7 @@ config_opts['chroot_setup_cmd'] = 'install bash bzip2 coreutils cpio diffutils r
 config_opts['dist'] = 'el6'  # only useful for --resultdir variable subst
 # beware RHEL use 6Server or 6Client
 config_opts['releasever'] = '6Server'
+config_opts['use_nspawn'] = False
 
 config_opts['yum.conf'] = """
 [main]

--- a/rhel-7-x86_64.cfg
+++ b/rhel-7-x86_64.cfg
@@ -4,6 +4,7 @@ config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'install bash bzip2 cpio diffutils gcc gcc-c++ gzip make patch perl rpm-build sed shadow-utils tar unzip which'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7Server'
+config_opts['use_nspawn'] = False
 
 config_opts['yum.conf'] = """
 [main]

--- a/script-env-vars-puppet-only.groovy
+++ b/script-env-vars-puppet-only.groovy
@@ -1,0 +1,12 @@
+env.REPO_ID=""
+env.PUPPET_REPO_ID="2369"
+env.TESTVM_HOSTCOLLECTION="Test Servers Jenkins pipeline"
+env.TESTVM_ENV="2"
+env.TEST_ROOT="redhat geheim"
+env.PUPPET_REPO="/var/www/html/pub/soe-puppet-only"
+env.CV="cv-puppet-only"
+env.CV_PASSIVE_LIST=""
+env.CCV_NAME_PATTERN=""
+env.CONDITIONAL_VM_BUILD=false
+env.PUPPET_DONE_SLEEP="0"
+env.MODAUTHOR="acme"

--- a/script-env-vars-rpm.groovy
+++ b/script-env-vars-rpm.groovy
@@ -1,0 +1,14 @@
+//this is for RHEL7 only as we build packages and shove them in a RHEL7 only yum repo
+env.REPO_ID="70"
+env.PUPPET_REPO_ID="71"
+env.TESTVM_HOSTCOLLECTION="Test Servers Jenkins pipeline"
+env.TESTVM_ENV="2"
+env.TEST_ROOT="redhat geheim"
+env.YUM_REPO="/var/www/html/pub/soe-repo/rhel7"
+env.PUPPET_REPO="/var/www/html/pub/soe-puppet"
+env.CV="cv-Jenkins-SOE-el7"
+env.CV_PASSIVE_LIST=""
+env.CCV_NAME_PATTERN=""
+env.CONDITIONAL_VM_BUILD=false
+env.MOCK_CONFIG="rhel-7-x86_64"
+env.PUPPET_DONE_SLEEP="75"

--- a/script-env-vars.groovy
+++ b/script-env-vars.groovy
@@ -1,0 +1,5 @@
+env.PUSH_USER="jenkins"
+env.RSA_ID="/var/lib/jenkins/.ssh/id_rsa"
+env.KNOWN_HOSTS="/var/lib/jenkins/.ssh/known_hosts"
+env.SATELLITE="satellite.internal.pcfe.net"
+env.ORG="Sat Test"

--- a/starttestvms.sh
+++ b/starttestvms.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Instruct Foreman to start the test VMs (just in case they are off)
+#
+# e.g ${WORKSPACE}/scripts/starttestvms.sh 'test'
+#
+# this will tell Foreman to rebuild all machines in hostgroup TESTVM_HOSTGROUP
+
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
+
+if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]  || [[ -z ${RSA_ID} ]] \
+   || [[ -z ${ORG} ]] || [[ -z ${TESTVM_HOSTCOLLECTION} ]]
+then
+    err "Environment variable PUSH_USER, SATELLITE, RSA_ID, ORG " \
+        "or TESTVM_HOSTCOLLECTION not set or not found."
+    exit ${WORKSPACE_ERR}
+fi
+
+get_test_vm_list # populate TEST_VM_LIST
+
+# TODO: Error out if no test VM's are available.
+if [ $(echo ${#TEST_VM_LIST[@]}) -eq 0 ]; then
+  err "No test VMs configured in Satellite"
+fi
+
+# rebuild test VMs
+for I in "${TEST_VM_LIST[@]}"
+do
+    info "Making sure VM ID $I is on"
+
+    _PROBED_STATUS=$(ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} "hammer host status --id $I" | grep Power | cut -f2 -d: | tr -d ' ')
+
+    # different hypervisors report power status with different words. parse and get a single word per status
+    # KVM uses running / shutoff
+    # VMware uses poweredOn / poweredOff
+    # add other hypervisors as you come across them and please submit to https://github.com/RedHatEMEA/soe-ci
+
+    case "${_PROBED_STATUS}" in
+      running)
+        _STATUS=On
+        ;;
+      poweredOn)
+        _STATUS=On
+        ;;
+      up)
+        _STATUS=On
+        ;;
+      shutoff)
+        _STATUS=Off
+        ;;
+      poweredOff)
+        _STATUS=Off
+        ;;
+      down)
+        _STATUS=Off
+        ;;
+      off)
+        _STATUS=Off
+        ;;
+      *)
+        echo "can not parse power status, please review $0"
+    esac
+
+    if [[ ${_STATUS} == 'On' ]]
+    then
+        info "Host $I is already on."
+    elif [[ ${_STATUS} == 'Off' ]]
+    then
+        info "Host $I is already off, switching it on."
+        ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+            "hammer host start --id $I"
+    else
+        err "Host $I is neither running nor shutoff. No action possible!"
+        # exit 0 while testingi for issue  #50,
+        # allows for manual rebooting of the test VM(s)
+        exit 0
+    fi
+done


### PR DESCRIPTION
@ericzolf pcfe thought you might want to have a look and play around.
basically this PR introduces the pipeline as code (aka Jenkinsfile). furthermore it combines the puppet-only feature with the rpm builds in one build job.
the beauty of it, is of course, that it's easy and maintained in the SCM (right now just git - other SCMs are on my feature list). so changes in your pipeline are treated as code changes. 
PR #71 should be merged before testing this, according to @pcfe