### PR TITLE
Wait for build of test VMs to end

### DIFF
--- a/buildtestvms.sh
+++ b/buildtestvms.sh
@@ -98,9 +98,9 @@ for I in "${TEST_VM_LIST[@]}"; do vmcopy[$I]=$I; done
 WAIT=0
 while [[ ${#vmcopy[@]} -gt 0 ]]
 do
-    inform "Waiting 10 seconds"
-    sleep 10
-    ((WAIT+=10))
+    inform "Waiting 1 minute"
+    sleep 60
+    ((WAIT+=60))
     for I in "${vmcopy[@]}"
     do
         inform "Checking if host $I is in build mode."

--- a/buildtestvms.sh
+++ b/buildtestvms.sh
@@ -90,7 +90,7 @@ done
 # this check was previously only in pushtests, but when using pipelines 
 # it's more sensible to wait here while the machines are in build mode
 # the ping and ssh checks must remain in pushtests.sh
-# as a pupet only build will not call tis script
+# as a pupet only build will not call this script
 
 declare -A vmcopy # declare an associative array to copy our VM array into
 for I in "${TEST_VM_LIST[@]}"; do vmcopy[$I]=$I; done

--- a/pushtests.sh
+++ b/pushtests.sh
@@ -10,21 +10,19 @@
 
 get_test_vm_list # populate TEST_VM_LIST
 
-# we need to wait until all the test machines have been rebuilt by foreman
+# we need to wait until all the test machines are up and can be ssh-ed to
 declare -A vmcopy # declare an associative array to copy our VM array into
 for I in "${TEST_VM_LIST[@]}"; do vmcopy[$I]=$I; done
 
 WAIT=0
 while [[ ${#vmcopy[@]} -gt 0 ]]
 do
-    inform "Waiting 10 seconds"
-    sleep 10
-    ((WAIT+=10))
+    inform "Waiting 15 seconds"
+    sleep 15
+    ((WAIT+=15))
     for I in "${vmcopy[@]}"
     do
-        inform "Checking if test server $I has rebooted into OS so that tests can be run"
-        inform "note that the Jenkins job definition may trigger a fresh installation,"
-        inform "so check the console of $I if this step is taking too long."
+        inform "Checking if test server $I has rebooted into OS so that tests can be run."
         status=$(ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
             "hammer host info --name $I | \
             grep -e \"Managed.*yes\" -e \"Enabled.*yes\" -e \"Build.*no\" \


### PR DESCRIPTION
This PR makes sure `buildtestvms.sh` only ends after the Test VMs are no longer in build mode. Previously `buildtestvms.sh` would return right after setting them into build mode putting the onus of waiting on `pushtests.sh`.

Addresses #93 

[tested on my home setup](http://jenkins.internal.pcfe.net:8080/view/testing/job/WaitForBuildOfVMs/3/console), works as expected.

 @jeichler if you cherry pick this to your branch we can better compare stage/script times of full builds with puppet-only builds.

###### for reviewers:
- In the logs you will see more time spent in the stage `REBUILDING TEST VMS` and less time in the stage `PUSHING TESTS to TEST VMS`.
- [For pipeline builds](https://github.com/RedHatSatellite/soe-ci/tree/jenkins_pipeline) this makes sure the time spent installing is counted towards `buildtestvms.sh` in `stage('run tests on VMs')`. Previously that time would be added to the run of `pushtests.sh`.
- one review should be enough to merge, no need for 5 people to review this.

pcfe