### PR TITLE
add ability to use image-based installs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,8 +34,8 @@ node {
     }
   }
   executeStage(stageCheckout, 'Checkout from Git')
-  
-  def stageLoadConfig = { 
+
+  def stageLoadConfig = {
     checkThatConfigFilesExist()
     environmentVariables()
   }
@@ -61,9 +61,10 @@ node {
   }
   executeStage(stagePubAndPromote, 'publish and promote CV')
 
+// hardcode for testing, add def later
   def stagePrepVms = {
     if (params.REBUILD_VMS == true) {
-      executeScript("${SCRIPTS_DIR}/buildtestvms.sh")
+      executeScript("${SCRIPTS_DIR}/buildtestvms-from-image.sh")
     } else {
       executeScript("${SCRIPTS_DIR}/starttestvms.sh")
     }
@@ -75,7 +76,7 @@ node {
     step([$class: "TapPublisher", testResults: "test_results/*.tap", ])
   }
   executeStage(stageRunTests, 'run tests')
-   
+
   def stagePowerOff = {
     if (params.POWER_OFF_VMS_AFTER_BUILD == true) {
       executeScript("${SCRIPTS_DIR}/powerofftestvms.sh")
@@ -102,7 +103,7 @@ def executeStage(Closure closure, String stageName) {
         currentBuild.result = 'FAILURE'
       }
     }
-  } 
+  }
 }
 
 /**
@@ -113,7 +114,7 @@ def executeStage(Closure closure, String stageName) {
 def checkThatConfigFilesExist() {
   filesMissing = false
   errorMessage = "The following config files are missing:"
-  [GENERAL_CONFIG_FILE, specificConfigFile].each { fileName -> 
+  [GENERAL_CONFIG_FILE, specificConfigFile].each { fileName ->
     if (fileExists("${fileName}") == false) {
       filesMissing = true
       errorMessage = errorMessage + " ${fileName}"
@@ -125,7 +126,7 @@ def checkThatConfigFilesExist() {
 }
 
 def environmentVariables() {
-  [GENERAL_CONFIG_FILE, specificConfigFile].each { fileName -> 
+  [GENERAL_CONFIG_FILE, specificConfigFile].each { fileName ->
     load "${fileName}"
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,10 @@ node {
   }
   executeStage(stagePubAndPromote, 'publish and promote CV')
 
-// hardcode for testing, add def later
+/*
+* if you do kickstart installs (the default), then execute buildtestvms.sh
+* if you do image-based installs, then execute buildtestvms-from-image.sh instead
+*/
   def stagePrepVms = {
     if (params.REBUILD_VMS == true) {
       executeScript("${SCRIPTS_DIR}/buildtestvms-from-image.sh")

--- a/buildtestvms-from-image.sh
+++ b/buildtestvms-from-image.sh
@@ -38,7 +38,7 @@ do
 
     inform "Recreating VM ID $I"
     ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
-        "hammer host create
+        "hammer host create \
 
 hammer host create \
 --name "kvm-test2" \
@@ -99,6 +99,10 @@ do
         then
             tell "host $I no longer in build mode."
             unset vmcopy[$I]
+            # reboot the box here so that new kernel is active
+            # this is only necessay on image based installs
+            tell "rebooting host $I since it applied errata as part of cloud-init and we want latest kernel and glibc active"
+            hammer host reboot --name $I
         else
             tell "host $I is still in build mode."
         fi

--- a/buildtestvms-from-image.sh
+++ b/buildtestvms-from-image.sh
@@ -103,7 +103,8 @@ do
             # reboot the box here so that new kernel is active
             # this is only necessay on image based installs
             tell "rebooting host $I since it applied errata as part of cloud-init and we want latest kernel and glibc active"
-            hammer host reboot --name $I
+            ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+                "hammer host reboot --name $I"
         else
             tell "host $I is still in build mode."
         fi

--- a/buildtestvms-from-image.sh
+++ b/buildtestvms-from-image.sh
@@ -58,28 +58,11 @@ do
          --enabled true \
          --managed true \
          --compute-attributes=\"start=1\""
-
-# do use 
-# --hostgroup-title "Test Servers/Jenkins pipeline SOE-CI/image-based"
-# because that I can get from a hammer host info output
-# hammer host info --name sattestclient05.sattest.pcfe.net|grep -e "^Organi[sz]ation" -e "^Host Group" -e "^Location"
-hammer host create \
---name "kvm-test2" \
---organization "Sat Test" \
---location "Bergmannstraße" \
---hostgroup "image-based" \
---provision-method image \
---enabled true \
---managed true \
---compute-attributes="start=1"
-
-
-
 done
 
 
 # we need to wait until all the test machines have been rebuilt by foreman
-# this check was previously only in pushtests, but when using pipelines 
+# this check was previously only in pushtests, but when using pipelines
 # it's more sensible to wait here while the machines are in build mode
 # the ping and ssh checks must remain in pushtests.sh
 # as a pupet only build will not call this script

--- a/buildtestvms-from-image.sh
+++ b/buildtestvms-from-image.sh
@@ -24,12 +24,6 @@ if [ $(echo ${#TEST_VM_LIST[@]}) -eq 0 ]; then
   err "No test VMs configured in Satellite"
 fi
 
-# rebuild test VMs
-# while testing, I disabled _Destroy associated VM on host delete_
-
-### also disabled for now
-exit 1
-
 # for each host; dump Org, Loc and HG in a file, process that
 
 for I in "${TEST_VM_LIST[@]}"

--- a/buildtestvms-from-image.sh
+++ b/buildtestvms-from-image.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Instruct Foreman to rebuild the test VMs
+#
+# e.g ${WORKSPACE}/scripts/buildtestvms.sh 'test'
+#
+# this will tell Foreman to rebuild all machines in hostgroup TESTVM_HOSTGROUP
+
+# Load common parameter variables
+. $(dirname "${0}")/common.sh
+
+if [[ -z ${PUSH_USER} ]] || [[ -z ${SATELLITE} ]]  || [[ -z ${RSA_ID} ]] \
+   || [[ -z ${ORG} ]] || [[ -z ${TESTVM_HOSTCOLLECTION} ]]
+then
+    err "Environment variable PUSH_USER, SATELLITE, RSA_ID, ORG " \
+        "or TESTVM_HOSTCOLLECTION not set or not found."
+    exit ${WORKSPACE_ERR}
+fi
+
+get_test_vm_list # populate TEST_VM_LIST
+
+# TODO: Error out if no test VM's are available.
+if [ $(echo ${#TEST_VM_LIST[@]}) -eq 0 ]; then
+  err "No test VMs configured in Satellite"
+fi
+
+# rebuild test VMs
+# while testing, I disabled _Destroy associated VM on host delete_
+
+### also disabled for now
+exit 1
+
+for I in "${TEST_VM_LIST[@]}"
+do
+    inform "Deleting VM ID $I"
+    ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+        "hammer host delete --id $I"
+
+    inform "Recreating VM ID $I"
+    ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+        "hammer host create
+
+hammer host create \
+--name "kvm-test2" \
+--organization "Sat Test" \
+--location "Bergmannstraße" \
+--hostgroup "image-based" \
+--provision-method image \
+--enabled true \
+--managed true \
+--compute-attributes="start=1"
+
+
+
+done
+
+
+# we need to wait until all the test machines have been rebuilt by foreman
+# this check was previously only in pushtests, but when using pipelines 
+# it's more sensible to wait here while the machines are in build mode
+# the ping and ssh checks must remain in pushtests.sh
+# as a pupet only build will not call this script
+
+declare -A vmcopy # declare an associative array to copy our VM array into
+for I in "${TEST_VM_LIST[@]}"; do vmcopy[$I]=$I; done
+
+# the below test from the kickstart based installs will also work for image based installs.
+# the stayus of Build: still changes
+#[root@satellite ~]# hammer host info --name kvm-test2.sattest.pcfe.net | grep -e "Managed" -e "Enabled" -e "Build"
+#Managed:                  yes
+#    Build Status:  Pending installation
+#    Build:                  yes
+#    Enabled:    yes
+#[root@satellite ~]# hammer host info --name kvm-test2.sattest.pcfe.net | grep -e "Managed" -e "Enabled" -e "Build"
+#Managed:                  yes
+#    Build Status:  Installed
+#    Build:                  no
+#    Enabled:    yes
+
+# But potentially also check for
+#  Build Status:  Pending installation
+# changing to
+#  Build Status:  Installed
+WAIT=0
+while [[ ${#vmcopy[@]} -gt 0 ]]
+do
+    inform "Waiting 1 minute"
+    sleep 60
+    ((WAIT+=60))
+    for I in "${vmcopy[@]}"
+    do
+        inform "Checking if host $I is in build mode."
+        status=$(ssh -q -l ${PUSH_USER} -i ${RSA_ID} ${SATELLITE} \
+            "hammer host info --name $I | \
+            grep -e \"Managed.*yes\" -e \"Enabled.*yes\" -e \"Build.*no\" \
+                | wc -l")
+        # Check if status is OK, then the SUT will have left build mode
+        if [[ ${status} == 3 ]]
+        then
+            tell "host $I no longer in build mode."
+            unset vmcopy[$I]
+        else
+            tell "host $I is still in build mode."
+        fi
+    done
+    if [[ ${WAIT} -gt 6000 ]]
+    then
+        err "At least one host still in build mode after 6000 seconds. Exiting."
+        exit 1
+    fi
+done
+

--- a/buildtestvms-from-image.sh
+++ b/buildtestvms-from-image.sh
@@ -2,7 +2,7 @@
 
 # Instruct Foreman to rebuild the test VMs
 #
-# e.g ${WORKSPACE}/scripts/buildtestvms.sh 'test'
+# e.g ${WORKSPACE}/scripts/buildtestvms-from-image.sh 'test'
 #
 # this will tell Foreman to rebuild all machines in hostgroup TESTVM_HOSTGROUP
 
@@ -65,7 +65,7 @@ declare -A vmcopy # declare an associative array to copy our VM array into
 for I in "${TEST_VM_LIST[@]}"; do vmcopy[$I]=$I; done
 
 # the below test from the kickstart based installs will also work for image based installs.
-# the stayus of Build: still changes
+# the status of Build: still changes
 #[root@satellite ~]# hammer host info --name kvm-test2.sattest.pcfe.net | grep -e "Managed" -e "Enabled" -e "Build"
 #Managed:                  yes
 #    Build Status:  Pending installation
@@ -76,11 +76,12 @@ for I in "${TEST_VM_LIST[@]}"; do vmcopy[$I]=$I; done
 #    Build Status:  Installed
 #    Build:                  no
 #    Enabled:    yes
-
+#
 # But potentially also check for
 #  Build Status:  Pending installation
 # changing to
 #  Build Status:  Installed
+
 WAIT=0
 while [[ ${#vmcopy[@]} -gt 0 ]]
 do

--- a/pushtests.sh
+++ b/pushtests.sh
@@ -75,7 +75,7 @@ do
     # if the repolist does not contain whet you expect, switch off auto-attach on the used activation-key
     inform "Listing repos on test server $I"
     ssh -o StrictHostKeyChecking=no -i ${RSA_ID} root@$I "subscription-manager repos"
-    
+
     # copy puppet-done-test.sh to SUT
     scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${RSA_ID} \
         ${WORKSPACE}/scripts/puppet-done-test.sh root@$I:

--- a/pushtests.sh
+++ b/pushtests.sh
@@ -76,6 +76,11 @@ do
     inform "Listing repos on test server $I"
     ssh -o StrictHostKeyChecking=no -i ${RSA_ID} root@$I "subscription-manager repos"
 
+    # force upload of package list to Satellite
+    # without this an image-based install shows up as katello-agent not installed in Satellite 6.5.3
+    # see https://access.redhat.com/solutions/1385683
+    ssh -o StrictHostKeyChecking=no -i ${RSA_ID} root@$I "katello-package-upload --force"
+
     # copy puppet-done-test.sh to SUT
     scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${RSA_ID} \
         ${WORKSPACE}/scripts/puppet-done-test.sh root@$I:

--- a/rhel-7-script-env-vars-puppet-only.groovy
+++ b/rhel-7-script-env-vars-puppet-only.groovy
@@ -1,5 +1,5 @@
 env.REPO_ID=""
-env.PUPPET_REPO_ID="2369"
+env.PUPPET_REPO_ID="9"
 env.TESTVM_HOSTCOLLECTION="Test Servers Jenkins pipeline"
 env.PUPPET_REPO="/var/www/html/pub/soe-puppet-only"
 env.CV="cv-puppet-only"

--- a/rhel-7-script-env-vars-rpm.groovy
+++ b/rhel-7-script-env-vars-rpm.groovy
@@ -1,7 +1,7 @@
 //this is for RHEL7 only as we build packages and shove them in a RHEL7 only yum repo
-env.REPO_ID="70"
-env.PUPPET_REPO_ID="71"
-env.TESTVM_HOSTCOLLECTION="Test Servers Jenkins pipeline"
+env.REPO_ID="10"
+env.PUPPET_REPO_ID="8"
+env.TESTVM_HOSTCOLLECTION="Test Servers installed from image"
 env.YUM_REPO="/var/www/html/pub/soe-repo/rhel7"
 env.PUPPET_REPO="/var/www/html/pub/soe-puppet"
 env.CV="cv-RHEL-Server-Jenkins-pipeline"


### PR DESCRIPTION
This PR adds the ability to instantiate the systems under test from images instead of normal kickstart.

Basically it boils down to the addition of `buildtestvms-from-image.sh` and a note in the Jenkinsfile.
it is quite intentional that the rest of soe-ci is unchanged.

(I need to do image-based installs at my current customer.)